### PR TITLE
reintegrated cache generation at server start

### DIFF
--- a/queryHandler/generateCache.js
+++ b/queryHandler/generateCache.js
@@ -1,0 +1,7 @@
+const axios  = require("axios")
+
+let generateCache = async () => {
+    await axios.get(process.env.BACK_END)
+}
+
+module.exports = generateCache;

--- a/queryHandler/pokemon151.js
+++ b/queryHandler/pokemon151.js
@@ -25,8 +25,7 @@ let Pokemon151 = async (req, res) => {
             
             cache[key] = pokemonArr;
             
-            let nameArray = pokemonNameArray(pokemonArr);
-            //console.log('names array: ' + nameArray);
+            pokemonNameArray(pokemonArr);
 
             pokemonConstructor();
 

--- a/queryHandler/pokemonConstructor.js
+++ b/queryHandler/pokemonConstructor.js
@@ -1,3 +1,8 @@
+// The main goal of this function is to take the query information from the
+// pokeapi and filter out all the information we don't need, and then modifying
+// the information we require and passing it into a pokemon constructor to create 
+// individual objects for each pokemon to send as a renderable package to our front end
+
 require('dotenv').config();
 const axios = require('axios');
 
@@ -12,7 +17,7 @@ let Pokemon = require('./pokemonClass');
 let pokemonConstructor = async (req, res) => {
     if(!cache[key]){
         console.log('Constructor Cache Miss');
-        console.log(resultsKey);
+        //console.log(resultsKey);
 
         let pokemonFromCache = cache[resultsKey];
 
@@ -61,7 +66,7 @@ let pokemonConstructor = async (req, res) => {
             if(counter == pokemonFromCache.length) {
                 newPokemonArr.sort((a,b) => (a.id > b.id) ? 1 : -1);
                 cache[key] = newPokemonArr;
-                console.log(cache[key]);
+                //console.log(cache[key]);
                 return cache[key];
             }
         });

--- a/server.js
+++ b/server.js
@@ -1,15 +1,15 @@
-//Importing and requiring of libraries and components
+//Importing and requiring of libraries and modules
 const express = require('express');
 const app = express();
 
 const cors = require('cors');
 app.use(cors());
 
-const axios = require('axios');
 require('dotenv').config();
 
 //getPokemon151 utilizes the pokeomonQuery, pokemonNameArry, pokemonconstructor, and pokemonClass
 const getPokemon151 = require('./queryHandler/pokemon151')
+const generateCache = require('./queryHandler/generateCache');
 
 const PORT = process.env.PORT || 3002;
 
@@ -18,14 +18,10 @@ let cache = require('./queryHandler/cache');
 let namesKey = process.env.PKMN_NAMES
 let objectsKey = process.env.PKMN_OBJECTS;
 
+generateCache();
+
 //--------------------------Routes---------------------------------
 app.get('/', getPokemon151);
-
-// querySelf = async () => {
-//     await axios.get(process.env.BACK_END);
-// }
-
-// querySelf();
 
 app.get('/151', (req, res) => res.send(cache[objectsKey]));
 


### PR DESCRIPTION
After discovering that the promise was not being delivered as expected when cache generation was attempted from a Front End query to the backend, it made more sense to have cache generation happen at the server start